### PR TITLE
Urls to re path

### DIFF
--- a/django_daraja/urls.py
+++ b/django_daraja/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import re_path as url, include
 from . import views
 
 test_patterns = [

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -13,7 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import re_path as url, include
 from django.contrib import admin
 
 urlpatterns = [


### PR DESCRIPTION
I fixe the problem [cannot import name 'url' from 'django.conf.urls' after upgrading ...].

By modifying the ```from django.urls.conf import url, include``` to ```from django.urls import re_path as url, include``` 