### PR TITLE
Update test dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,39 +3,17 @@ orbs:
   python: circleci/python@1.5.0
 
 jobs:
-  build-and-test-py-27-django-1-8:
+  build-and-test-py-311-django-4-1:
     docker:
-      - image: cimg/python:3.9.0
+      - image: cimg/python:3.11.0
     steps:
       - checkout
       - python/install-packages:
           pkg-manager: pip
       - run:
           name: Run tests
-          command: pip install tox && tox -e py27-django1.8
-  build-and-test-py-27-django-1-11:
-    docker:
-      - image: cimg/python:3.9.0
-    steps:
-      - checkout
-      - python/install-packages:
-          pkg-manager: pip
-      - run:
-          name: Run tests
-          command: pip install tox && tox -e py27-django1.11
-  build-and-test-py-39-django-2-1:
-    docker:
-      - image: cimg/python:3.9.0
-    steps:
-      - checkout
-      - python/install-packages:
-          pkg-manager: pip
-      - run:
-          name: Run tests
-          command: pip install tox && tox -e py39-django2.1
+          command: pip install tox && tox -e py311-django4.1
 workflows:
   sample:
     jobs:
-      - build-and-test-py-27-django-1-8
-      - build-and-test-py-27-django-1-11
-      - build-and-test-py-39-django-2-1
+      - build-and-test-py-311-django-4-1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -111,8 +111,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = 'lkk8@h!zhe4lxwf1!t=#5@bm(iuep+t+e6xik=4*lo(yy3u=f!'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['testserver']
 
 
 # Application definition

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,6 @@
 [tox]
 envlist =
-    py27-django1.8,
-    py27-django1.11,
-    py39-django2.1
-
-[django1.8]
-deps =
-    Django>=1.8,<1.9
-
-[django1.11]
-deps =
-    Django>=1.11,<2.0
-
-[django2.1]
-deps =
-    Django>=2.1,<2.2
+    py311-django4.1
 
 [testenv]
 passenv = 
@@ -31,19 +17,10 @@ passenv =
     B2C_PHONE_NUMBER
 
 commands =
-    python {toxinidir}/setup.py test
+    python {toxinidir}/manage.py test
 
-[testenv:py27-django1.8]
-basepython = python2.7
+[testenv:py311-django4.1]
+description = Use Python 3.11 and Django 4.1 in a virtual environment and run tests against it.
+basepython = python3.11
 deps =
-    {[django1.8]deps}
-
-[testenv:py27-django1.11]
-basepython = python2.7
-deps =
-    {[django1.11]deps}
-
-[testenv:py39-django2.1]
-basepython = python3.9
-deps =
-    {[django2.1]deps}
+    Django>=4.1,<4.2

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,6 @@ description = Use Python 3.11 and Django 4.1 in a virtual environment and run te
 basepython = python3.11
 deps =
     Django>=4.1,<4.2
-    pytest>=7
+    pytest-django>=4
     pytest-sugar
 commands = pytest tests {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,11 @@ passenv =
     LNM_PHONE_NUMBER
     B2C_PHONE_NUMBER
 
-commands =
-    python {toxinidir}/manage.py test
-
 [testenv:py311-django4.1]
 description = Use Python 3.11 and Django 4.1 in a virtual environment and run tests against it.
 basepython = python3.11
 deps =
     Django>=4.1,<4.2
+    pytest>=7
+    pytest-sugar
+commands = pytest tests {posargs}


### PR DESCRIPTION
This PR updates the test dependencies to use the latest tox configuration format. The following dependency versions are used for testing:
- Python 3.11
- Django 4.1

Python 2.7 tests have been removed since the version reached End of Life 3 years ago.